### PR TITLE
Add Julia example [WIP]

### DIFF
--- a/http/get_simple/julia/Project.toml
+++ b/http/get_simple/julia/Project.toml
@@ -1,0 +1,4 @@
+[deps]
+Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"
+HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
+Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"

--- a/http/get_simple/julia/client/README.md
+++ b/http/get_simple/julia/client/README.md
@@ -1,0 +1,32 @@
+<!---
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+# HTTP GET Arrow Data: Simple Julia Client Example
+
+This directory contains a minimal example of an HTTP client implemented in Julia. The client:
+1. Sends an HTTP GET request to a server.
+2. Receives an HTTP 200 response from the server, with the response body containing an Arrow IPC stream of record batches.
+3. Adds the record batches to a list as they are received.
+
+To run this example, first start one of the server examples in the parent directory, then:
+
+```sh
+julia --project=.. -e "using Pkg; Pkg.instantiate()"
+julia --project=.. client.jl
+```

--- a/http/get_simple/julia/client/client.jl
+++ b/http/get_simple/julia/client/client.jl
@@ -1,0 +1,33 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+using Arrow, HTTP
+
+function get_batches()
+    res = HTTP.get("http://localhost:8008")
+    buffer = res.body
+    stream = Arrow.Stream(res.body)
+    batches = collect(stream)
+
+    println("$(length(buffer)) bytes received")
+    println("$(length(batches)) record batches received")
+    
+    return batches
+end
+
+execution_time = @elapsed get_batches()
+println("$(execution_time) seconds elapsed")

--- a/http/get_simple/julia/server/README.md
+++ b/http/get_simple/julia/server/README.md
@@ -1,0 +1,32 @@
+<!---
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+# HTTP GET Arrow Data: Simple Julia Server Example
+
+This directory contains a minimal example of an HTTP server implemented in Julia. The server:
+1. Creates a list of record batches and populates it with synthesized data.
+2. Listens for HTTP GET requests from clients.
+3. Upon receiving a request, sends an HTTP 200 response with the body containing an Arrow IPC stream of record batches.
+
+To run this example:
+
+```sh
+julia --project=.. -e "using Pkg; Pkg.instantiate()"
+julia --project=.. server.jl
+```

--- a/http/get_simple/julia/server/server.jl
+++ b/http/get_simple/julia/server/server.jl
@@ -1,0 +1,40 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+using Arrow, HTTP, Tables
+
+function get_stream(::HTTP.Request)
+    total_records = 10_000_000
+    batch_len = 4096
+    stream = Tables.partitioner(Iterators.partition(1:total_records, batch_len)) do indices
+        nrows = length(indices)
+        return (
+            a = rand(Int, nrows),
+            b = rand(Int, nrows),
+            c = rand(Int, nrows),
+            d = rand(Int, nrows)
+        )
+    end
+    buffer = IOBuffer()
+    Arrow.write(buffer, stream)
+    return HTTP.Response(200, take!(buffer))
+end
+
+const ARROW_ROUTER = HTTP.Router()
+HTTP.register!(ARROW_ROUTER, "GET", "/", get_stream)
+println("Serving on localhost:8008...")
+server = HTTP.serve!(ARROW_ROUTER, "127.0.0.1", 8008)

--- a/http/get_simple/julia/server/server.jl
+++ b/http/get_simple/julia/server/server.jl
@@ -18,7 +18,7 @@
 using Arrow, HTTP, Tables
 
 function get_stream(::HTTP.Request)
-    total_records = 10_000_000
+    total_records = 100_000_000
     batch_len = 4096
     stream = Tables.partitioner(Iterators.partition(1:total_records, batch_len)) do indices
         nrows = length(indices)


### PR DESCRIPTION
Issues:
- Server does not work with `total_records = 100_000_000`. It throws an error related to libuv.

Julia client tested with
- [x] Python server
- [ ] Go server
- [ ] C-sharp server
- [ ] Java server
- [ ] Rust server
- [ ] Ruby server

Julia server tested with
- [ ] Python client
- [ ] Go client
- [ ] C client
- [ ] C++ client
- [ ] C-sharp client
- [ ] Java client
- [ ] Javascript client
- [ ] R client
- [ ] Rust client
- [ ] Ruby client